### PR TITLE
Add to_tree implementation and tests

### DIFF
--- a/anjl/__init__.py
+++ b/anjl/__init__.py
@@ -1,1 +1,2 @@
 from ._canonical import canonical_nj  # noqa
+from ._tree import to_tree, Node  # noqa

--- a/anjl/_layout.py
+++ b/anjl/_layout.py
@@ -1,0 +1,2 @@
+def layout_equal_angle():
+    pass  # TODO

--- a/anjl/_tree.py
+++ b/anjl/_tree.py
@@ -1,0 +1,74 @@
+class Node:
+    def __init__(self, id):
+        self.id = id
+        self.left = None
+        self.right = None
+        self.dist = None  # distance to parent
+        self.count = 1  # leaf count
+
+    def to_string(self, indent=""):
+        s = indent + repr(self) + "\n"
+        if self.left:
+            s += self.left.to_string(indent=indent + "    ")
+        if self.right:
+            s += self.right.to_string(indent=indent + "    ")
+        return s
+
+    def __str__(self):
+        return self.to_string().strip()
+
+    def __repr__(self):
+        return f"Node(id={self.id}, dist={self.dist}, count={self.count})"
+
+    @property
+    def is_leaf(self):
+        return self.count == 1
+
+
+def to_tree(Z, distance_sort=False, count_sort=False, rd=False):
+    n_internal = Z.shape[0]
+    n_original = n_internal + 1
+    n_nodes = n_original + n_internal
+    nodes = [Node(i) for i in range(n_nodes)]
+
+    for i in range(n_internal):
+        # Access the current parent node.
+        parent_id = n_original + i
+        parent = nodes[parent_id]
+
+        # Access data about the children.
+        left_id, right_id, left_dist, right_dist, leaf_count = Z[i]
+        left_id = int(left_id)
+        right_id = int(right_id)
+        left = nodes[left_id]
+        right = nodes[right_id]
+
+        # Assign the children and leaf count.
+        parent.left = left
+        parent.right = right
+        parent.count = int(leaf_count)
+
+        # Set distances for the children
+        left.dist = float(left_dist)
+        right.dist = float(right_dist)
+
+    if distance_sort:
+        for node in nodes:
+            if node.left:
+                left, right = sorted([node.left, node.right], key=lambda c: c.dist)
+                node.left = left
+                node.right = right
+
+    if count_sort:
+        for node in nodes:
+            if node.left:
+                left, right = sorted([node.left, node.right], key=lambda c: c.count)
+                node.left = left
+                node.right = right
+
+    root = nodes[-1]
+
+    if rd:
+        return root, nodes
+    else:
+        return root

--- a/notebooks/tree.ipynb
+++ b/notebooks/tree.ipynb
@@ -1,0 +1,382 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9b8a35c3-4339-4220-8298-d801695057bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import anjl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96412eba-de30-4139-9ce8-8f0bf2887b94",
+   "metadata": {},
+   "source": [
+    "## Example 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "495d1add-4a95-4a62-af2c-42bede13b479",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0. , 1. , 1. , 3. , 2. ],\n",
+       "       [2. , 4. , 2. , 2. , 3. ],\n",
+       "       [3. , 5. , 3.5, 3.5, 4. ]], dtype=float32)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "D1 = np.array(\n",
+    "    [  # A B C D\n",
+    "        [0, 4, 5, 10],\n",
+    "        [4, 0, 7, 12],\n",
+    "        [5, 7, 0, 9],\n",
+    "        [10, 12, 9, 0],\n",
+    "    ],\n",
+    "    dtype=np.float32,\n",
+    ")\n",
+    "Z1 = anjl.canonical_nj(D1)\n",
+    "Z1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f6fd6826-90a7-4303-8b01-340b0147cd72",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Node(id=6, dist=None, count=4)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root1 = anjl.to_tree(Z1)\n",
+    "root1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c0b3340e-d760-46af-80fd-9c27fab9b351",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Node(id=6, dist=None, count=4),\n",
+       " [Node(id=0, dist=1.0, count=1),\n",
+       "  Node(id=1, dist=3.0, count=1),\n",
+       "  Node(id=2, dist=2.0, count=1),\n",
+       "  Node(id=3, dist=3.5, count=1),\n",
+       "  Node(id=4, dist=2.0, count=2),\n",
+       "  Node(id=5, dist=3.5, count=3),\n",
+       "  Node(id=6, dist=None, count=4)])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root1, nodes1 = anjl.to_tree(Z1, rd=True)\n",
+    "root1, nodes1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "62636a5d-2c27-4921-b379-d28cc64eea47",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(id=6, dist=None, count=4)\n",
+      "    Node(id=3, dist=3.5, count=1)\n",
+      "    Node(id=5, dist=3.5, count=3)\n",
+      "        Node(id=2, dist=2.0, count=1)\n",
+      "        Node(id=4, dist=2.0, count=2)\n",
+      "            Node(id=0, dist=1.0, count=1)\n",
+      "            Node(id=1, dist=3.0, count=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(root1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "edd0497f-001b-42a2-8784-310a56dec9dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(id=6, dist=None, count=4)\n",
+      "    Node(id=3, dist=3.5, count=1)\n",
+      "    Node(id=5, dist=3.5, count=3)\n",
+      "        Node(id=2, dist=2.0, count=1)\n",
+      "        Node(id=4, dist=2.0, count=2)\n",
+      "            Node(id=0, dist=1.0, count=1)\n",
+      "            Node(id=1, dist=3.0, count=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(anjl.to_tree(Z1, count_sort=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "26919307-3607-4479-b375-3a2684a1e7be",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(id=6, dist=None, count=4)\n",
+      "    Node(id=3, dist=3.5, count=1)\n",
+      "    Node(id=5, dist=3.5, count=3)\n",
+      "        Node(id=2, dist=2.0, count=1)\n",
+      "        Node(id=4, dist=2.0, count=2)\n",
+      "            Node(id=0, dist=1.0, count=1)\n",
+      "            Node(id=1, dist=3.0, count=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(anjl.to_tree(Z1, distance_sort=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3116feb1-ea5b-4bf3-a4e7-d3efcb5a884d",
+   "metadata": {},
+   "source": [
+    "## Example 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a1a20809-af7b-4071-80e5-5be768e907c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0. , 1. , 2. , 3. , 2. ],\n",
+       "       [2. , 5. , 4. , 3. , 3. ],\n",
+       "       [3. , 6. , 2. , 2. , 4. ],\n",
+       "       [4. , 7. , 0.5, 0.5, 5. ]], dtype=float32)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "D2 = np.array(\n",
+    "    [  # a b c d e\n",
+    "        [0, 5, 9, 9, 8],\n",
+    "        [5, 0, 10, 10, 9],\n",
+    "        [9, 10, 0, 8, 7],\n",
+    "        [9, 10, 8, 0, 3],\n",
+    "        [8, 9, 7, 3, 0],\n",
+    "    ],\n",
+    "    dtype=np.float32,\n",
+    ")\n",
+    "Z2 = anjl.canonical_nj(D2)\n",
+    "Z2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "66ccc598-3bc6-4c01-bf1b-2656b9671756",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Node(id=8, dist=None, count=5)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root2 = anjl.to_tree(Z2)\n",
+    "root2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0c532022-fc73-4430-b374-93b97f6d49c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Node(id=8, dist=None, count=5),\n",
+       " [Node(id=0, dist=2.0, count=1),\n",
+       "  Node(id=1, dist=3.0, count=1),\n",
+       "  Node(id=2, dist=4.0, count=1),\n",
+       "  Node(id=3, dist=2.0, count=1),\n",
+       "  Node(id=4, dist=0.5, count=1),\n",
+       "  Node(id=5, dist=3.0, count=2),\n",
+       "  Node(id=6, dist=2.0, count=3),\n",
+       "  Node(id=7, dist=0.5, count=4),\n",
+       "  Node(id=8, dist=None, count=5)])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root2, nodes2 = anjl.to_tree(Z2, rd=True)\n",
+    "root2, nodes2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "67bcc474-70a3-4e0f-972a-49d82988fb5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(id=8, dist=None, count=5)\n",
+      "    Node(id=4, dist=0.5, count=1)\n",
+      "    Node(id=7, dist=0.5, count=4)\n",
+      "        Node(id=3, dist=2.0, count=1)\n",
+      "        Node(id=6, dist=2.0, count=3)\n",
+      "            Node(id=2, dist=4.0, count=1)\n",
+      "            Node(id=5, dist=3.0, count=2)\n",
+      "                Node(id=0, dist=2.0, count=1)\n",
+      "                Node(id=1, dist=3.0, count=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(root2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1bd0221c-888d-4182-998c-facf52444667",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(id=8, dist=None, count=5)\n",
+      "    Node(id=4, dist=0.5, count=1)\n",
+      "    Node(id=7, dist=0.5, count=4)\n",
+      "        Node(id=3, dist=2.0, count=1)\n",
+      "        Node(id=6, dist=2.0, count=3)\n",
+      "            Node(id=2, dist=4.0, count=1)\n",
+      "            Node(id=5, dist=3.0, count=2)\n",
+      "                Node(id=0, dist=2.0, count=1)\n",
+      "                Node(id=1, dist=3.0, count=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(anjl.to_tree(Z2, count_sort=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "95331202-99b7-4415-8353-e1e89c53f9ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(id=8, dist=None, count=5)\n",
+      "    Node(id=4, dist=0.5, count=1)\n",
+      "    Node(id=7, dist=0.5, count=4)\n",
+      "        Node(id=3, dist=2.0, count=1)\n",
+      "        Node(id=6, dist=2.0, count=3)\n",
+      "            Node(id=5, dist=3.0, count=2)\n",
+      "                Node(id=0, dist=2.0, count=1)\n",
+      "                Node(id=1, dist=3.0, count=1)\n",
+      "            Node(id=2, dist=4.0, count=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(anjl.to_tree(Z2, distance_sort=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "950d0417-cd58-4801-9d4a-59ab11061466",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -35,38 +35,6 @@ def validate_nj_result(Z, D):
     assert int(Z[-1, 4]) == n_original
 
 
-def test_wikipedia():
-    # This example comes from the wikipedia page on neighbour-joining.
-    # https://en.wikipedia.org/wiki/Neighbor_joining#Example
-
-    D = np.array(
-        [  # a b c d e
-            [0, 5, 9, 9, 8],
-            [5, 0, 10, 10, 9],
-            [9, 10, 0, 8, 7],
-            [9, 10, 8, 0, 3],
-            [8, 9, 7, 3, 0],
-        ],
-        dtype=np.float32,
-    )
-    Z = anjl.canonical_nj(D)
-    validate_nj_result(Z, D)
-
-    # First iteration.
-    left, right, ldist, rdist, leaves = Z[0]
-    # Expect nodes 0 and 1 to be joined.
-    assert int(left) == 0
-    assert int(right) == 1
-    # Expect distances are 2 and 3 respectively.
-    assert_allclose(ldist, 2)
-    assert_allclose(rdist, 3)
-    # Expect 2 leaves in the clade.
-    assert int(leaves) == 2
-
-    # Further iterations cannot be tested because there are
-    # different ways the remaining nodes could be joined.
-
-
 def test_amelia_harrison():
     # This example comes from Amelia Harrison's blog.
     # https://www.tenderisthebyte.com/blog/2022/08/31/neighbor-joining-trees/
@@ -115,3 +83,35 @@ def test_amelia_harrison():
     assert_allclose(ldist, 3.5)
     assert_allclose(rdist, 3.5)
     assert int(leaves) == 4
+
+
+def test_wikipedia():
+    # This example comes from the wikipedia page on neighbour-joining.
+    # https://en.wikipedia.org/wiki/Neighbor_joining#Example
+
+    D = np.array(
+        [  # a b c d e
+            [0, 5, 9, 9, 8],
+            [5, 0, 10, 10, 9],
+            [9, 10, 0, 8, 7],
+            [9, 10, 8, 0, 3],
+            [8, 9, 7, 3, 0],
+        ],
+        dtype=np.float32,
+    )
+    Z = anjl.canonical_nj(D)
+    validate_nj_result(Z, D)
+
+    # First iteration.
+    left, right, ldist, rdist, leaves = Z[0]
+    # Expect nodes 0 and 1 to be joined.
+    assert int(left) == 0
+    assert int(right) == 1
+    # Expect distances are 2 and 3 respectively.
+    assert_allclose(ldist, 2)
+    assert_allclose(rdist, 3)
+    # Expect 2 leaves in the clade.
+    assert int(leaves) == 2
+
+    # Further iterations cannot be tested because there are
+    # different ways the remaining nodes could be joined.

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,131 @@
+from textwrap import dedent
+import numpy as np
+from numpy.testing import assert_allclose
+import anjl
+
+
+def test_amelia_harrison():
+    # This example comes from Amelia Harrison's blog.
+    # https://www.tenderisthebyte.com/blog/2022/08/31/neighbor-joining-trees/
+
+    D = np.array(
+        [  # A B C D
+            [0, 4, 5, 10],
+            [4, 0, 7, 12],
+            [5, 7, 0, 9],
+            [10, 12, 9, 0],
+        ],
+        dtype=np.float32,
+    )
+    Z = anjl.canonical_nj(D)
+    n_original = D.shape[0]
+    n_internal = n_original - 1
+    n_nodes = n_original + n_internal
+
+    # Default options.
+    root = anjl.to_tree(Z)
+    assert isinstance(root, anjl.Node)
+    assert root.id == n_nodes - 1
+    assert root.dist is None
+    assert root.count == n_original
+    assert not root.is_leaf
+
+    # First level.
+    left = root.left
+    right = root.right
+    assert left.id == 3
+    assert_allclose(left.dist, 3.5)
+    assert left.count == 1
+    assert left.is_leaf
+    assert left.left is None
+    assert left.right is None
+    assert right.id == 5
+    assert_allclose(right.dist, 3.5)
+    assert right.count == 3
+    assert not right.is_leaf
+    assert right.left is not None
+    assert right.right is not None
+
+    # Second level.
+    parent = right
+    left = parent.left
+    right = parent.right
+    assert left.id == 2
+    assert_allclose(left.dist, 2.0)
+    assert left.count == 1
+    assert left.is_leaf
+    assert left.left is None
+    assert left.right is None
+    assert right.id == 4
+    assert_allclose(right.dist, 2.0)
+    assert right.count == 2
+    assert not right.is_leaf
+    assert right.left is not None
+    assert right.right is not None
+
+    # Third level.
+    parent = right
+    left = parent.left
+    right = parent.right
+    assert left.id == 0
+    assert_allclose(left.dist, 1.0)
+    assert left.count == 1
+    assert left.is_leaf
+    assert left.left is None
+    assert left.right is None
+    assert right.id == 1
+    assert_allclose(right.dist, 3.0)
+    assert right.count == 1
+    assert right.is_leaf
+    assert right.left is None
+    assert right.right is None
+
+    # String representation.
+    expected_repr = "Node(id=6, dist=None, count=4)"
+    assert repr(root) == expected_repr
+
+    # String value.
+    expected_str = dedent("""
+        Node(id=6, dist=None, count=4)
+            Node(id=3, dist=3.5, count=1)
+            Node(id=5, dist=3.5, count=3)
+                Node(id=2, dist=2.0, count=1)
+                Node(id=4, dist=2.0, count=2)
+                    Node(id=0, dist=1.0, count=1)
+                    Node(id=1, dist=3.0, count=1)
+    """).strip()
+    assert str(root) == expected_str
+
+    # Also request list of nodes.
+    root, nodes = anjl.to_tree(Z, rd=True)
+    assert isinstance(root, anjl.Node)
+    assert isinstance(nodes, list)
+    assert len(nodes) == n_nodes
+    for i, node in enumerate(nodes):
+        assert isinstance(node, anjl.Node)
+        assert node.id == i
+        if i >= n_original:
+            # Internal node.
+            assert node.count > 1
+            assert not node.is_leaf
+            assert node.left is not None
+            assert isinstance(node.left, anjl.Node)
+            assert node.right is not None
+            assert isinstance(node.right, anjl.Node)
+        else:
+            assert node.count == 1
+            assert node.is_leaf
+            assert node.left is None
+            assert node.right is None
+
+    # Count sort.
+    _, nodes = anjl.to_tree(Z, rd=True, count_sort=True)
+    for node in nodes:
+        if not node.is_leaf:
+            assert node.left.count <= node.right.count
+
+    # Distance sort.
+    _, nodes = anjl.to_tree(Z, rd=True, distance_sort=True)
+    for node in nodes:
+        if not node.is_leaf:
+            assert node.left.dist <= node.right.dist


### PR DESCRIPTION
Adds a `to_tree()` function with tests and demo notebook.

This mostly parallels the scipy `to_tree()` function, with the notable exception that the `dist` attribute is the distance to the parent node.