### PR TITLE
Remove unsafe update of global_q_xy

### DIFF
--- a/anjl/_dynamic.py
+++ b/anjl/_dynamic.py
@@ -491,9 +491,9 @@ def dynamic_search_parallel(
                 if q_iz < q_i:
                     Q[i] = q_iz
 
-            if q_i > global_q_xy:
+            if q_i > local_q_xy:
                 # We can skip this row. The previous row optimum join criterion is greater
-                # than the current global optimum, and so there is now way that this row
+                # than the current local optimum, and so there is now way that this row
                 # can contain a better match. This is the core optimisation of the dynamic
                 # algorithm.
                 continue
@@ -516,10 +516,6 @@ def dynamic_search_parallel(
                 local_d_xy = d_ij
                 local_x = i
                 local_y = j
-
-                # Share update between threads, in case it helps other threads skip
-                # more rows. This is a supported parallel reduction.
-                global_q_xy = min(global_q_xy, local_q_xy)
 
         # Store results for this thread.
         results_q_xy[t] = local_q_xy


### PR DESCRIPTION
This issue was found through investigating https://github.com/malariagen/malariagen-data-python/issues/938.

The `dynamic_search_parallel()` function looks something like this:

```python
global_y, global_q_xy, global_d_xy = search_row(...)

# Set up parallel threads.
for t in prange(n_threads):
    # Thread local variables.
    local_q_xy = global_q_xy
    local_d_xy = global_d_xy
    local_x = global_x
    local_y = global_y

    for _i in range(t, n_original, n_threads):

        q_ij = ...
        
        if q_ij < local_q_xy:
            # Found new minimum.
            local_q_xy = q_ij
            local_d_xy = d_ij
            local_x = i
            local_y = j

            # Share update between threads, in case it helps other threads skip
            # more rows. This is a supported parallel reduction.
            global_q_xy = min(global_q_xy, local_q_xy)
```

Updating `global_q_xy` inside the threads leads to a subtle race condition as follows:

1. The first call to `search_row()` doesn't find a minimum and sets
    ```python
    global_y = UINTP_MAX
    global_q_xy = FLOAT32_INF
    ```
2. Thread 2 is scheduled first and happens to find the overall global minimum, say -100. It saves the index of the minimum in  `local_y` and updates `global_q_xy` to the new minimum. However, `global_y` is never updated.
    ```python
    global_y = UINTP_MAX
    global_q_xy = -100
    ```
3. Thread 1 is scheduled after thread 2, and it initializes
    ```python
    local_y = global_y  # UINTP_MAX
    local_q_xy = global_q_xy  # -100
   ```
4. Thread 1 thinks it has found the global minimum and saves the minimum in its result arrays. However, it has the wrong index.
5. When all of the results are compared at the end, thread 1 comes in the result arrays before thread 2, and so the wrong index (UINTP_MAX) is returned. This causes an assertion error `assert y < n_original` in the parent `dynamic_iteration()` algorithm.

In this case the error is caught because UINTP_MAX triggers an assertion. However, if the first call to `search_row()` returns a valid index I believe it would subtly return the wrong answer without triggering an error.

The fix is to remove the update of `global_q_xy` so that all the threads run independently and compare their answers at the end. (In theory if `global_y` were updated alongside `global_q_xy` whenever it finds a new min I believe that would solve this problem, though in practice numba doesn't have any synchronization primitives able to express this.) Furthermore, the numba documentation states that "For the max and min functions, the reduction variable should hold the identity value right before entering the prange loop", which in general we can't guarantee will be the case here. So it's safest to just remove it.